### PR TITLE
Add .gitignore, interpolate unsupported OS into notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,58 @@
+
+# vi{,m} global ignores, copied from 
+# https://github.com/github/gitignore/blob/master/Global/Vim.gitignore
+# swap
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+# session
+Session.vim
+# temporary
+.netrwhist
+*~
+# auto-generated tag files
+tags
+
+# emacs global ignores, copied from
+# https://github.com/github/gitignore/blob/master/Global/Emacs.gitignore
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# mode: gitignore;

--- a/modules/autopatch/manifests/init.pp
+++ b/modules/autopatch/manifests/init.pp
@@ -8,7 +8,7 @@ class autopatch
 	 	   	source => "puppet:///modules/ubuntu/auto-upgrade",
 			}
 		default: {
-			notify { "this OS is not support, to fix go to http://github.com/ucdavis/ucdpuppet and open an issue or a pull request"}
+			notify { "OS ${operatingsystem} is not supported, to fix go to http://github.com/ucdavis/ucdpuppet and open an issue or a pull request"}
       }
 }
 

--- a/modules/ssh/manifests/init.pp
+++ b/modules/ssh/manifests/init.pp
@@ -10,7 +10,7 @@ class ssh {
 			}
 		}
 		default: {
-			notify { "this OS is not supported, to fix go to http://github.com/ucdavis/ucdpuppet and open an issue or a pull request"}
+			notify { "OS ${operatingsystem} is not supported, to fix go to http://github.com/ucdavis/ucdpuppet and open an issue or a pull request"}
    	}
 	}
 }
@@ -25,7 +25,7 @@ class ssh::nopassword inherits ssh {
 		notify => Service[ssh]
 	}
 	default: {
-		notify { "this OS is not supported, to fix go to http://github.com/ucdavis/ucdpuppet and open an issue or a pull request"}
+		notify { "OS ${operatingsystem} is not supported, to fix go to http://github.com/ucdavis/ucdpuppet and open an issue or a pull request"}
 	}
 }
 

--- a/modules/unbound/manifests/init.pp
+++ b/modules/unbound/manifests/init.pp
@@ -5,7 +5,7 @@ class unbound {
 		}
 		#'RedHat', 'CentOS': { ... }
 		default: {
-			 notify { "this OS is not support, to fix go to http://github.com/ucdavis/ucdpuppet and open an issue or a pull request"}
+			 notify { "OS ${operatingsystem} is not supported, to fix go to http://github.com/ucdavis/ucdpuppet and open an issue or a pull request"}
 		}
 }
 
@@ -17,7 +17,7 @@ class unbound::networkmanager inherits unbound {
 			}
 		}
 		default: {
-			 notify { "this OS is not support, to fix go to http://github.com/ucdavis/ucdpuppet and open an issue or a pull request"}
+			 notify { "OS ${operatingsystem} is not supported, to fix go to http://github.com/ucdavis/ucdpuppet and open an issue or a pull request"}
 		}
 	}
 }


### PR DESCRIPTION
I think it would be helpful if the OS name (as Puppet knows it) were interpolated into the notification messages. This might save some poor schmuck (such as yours truly) from scratching their head due to a typo in the regex.

I don't have a testing environment set up yet, so don't merge without testing!

Also added global .gitignore with vim and emacs editor files. (I noticed a .swp file in one of the directories, Bill.)
